### PR TITLE
heading in about modal was thrown off from other styles

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -137,6 +137,11 @@ footer p strong{
     cursor: pointer;
 }
 
+/* heading in about modal */
+#modal-content-area h3{
+    margin: 0;
+}
+
 /* Media Query for small screen Moble*/
 
 @media only screen and (max-width: 600px) {


### PR DESCRIPTION
Set margin specifically on h3 in modal to 0 to move it back in the top, after last merge it was centered in the modal