### PR TITLE
fixed bug in function searchByKeyword(); added resultsArea.innerHTML …

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -615,6 +615,7 @@ var searchByGenre = function (genreDataId) {
 
 // take text entered by user and use multi search endpoint from TMDB API to return results with that word
 function searchByKeyword (input) {
+    resultsArea.innerHTML = '';
     let keywordUrl = `${theMovieDbUrl}search/multi?api_key=${theMovieDbApiKey}&query=${input}`;
     fetch(keywordUrl)
     .then(function (response) {


### PR DESCRIPTION
I fixed the bug that was causing the search to populate more than 10 results; now the results area clears previous results when new keyword is searched. script.js line 618 now reads: resultsArea.innerHTML = '';